### PR TITLE
Added function to set WP editor settings

### DIFF
--- a/core/classes/fields/kt_wp_editor_field.inc.php
+++ b/core/classes/fields/kt_wp_editor_field.inc.php
@@ -4,9 +4,12 @@ class KT_WP_Editor_Field extends KT_Field {
 
     const FIELD_TYPE = "wp-editor";
 
+    private $settings = array();
+
     public function __construct($name, $label) {
         parent::__construct($name, $label);
         $this->setFilterSanitize(FILTER_DEFAULT);
+        $this->setDefaultSettings();
     }
 
     // --- gettery a settery ---------------------------
@@ -28,16 +31,33 @@ class KT_WP_Editor_Field extends KT_Field {
         $this->renderField();
     }
 
-    // --- veřejné metody ---------------------------
-
-    public function renderField() {
-        wp_editor($this->getValue(), $this->getName(), array(
+    /**
+     * Set default WP editor settings on field init
+     */
+    public function setDefaultSettings() {
+        $defaultSettings = array(
             "media_buttons" => false,
             "textarea_name" => $this->getNameAttribute(),
             "textarea_rows" => 10,
             "teeny" => false,
             "quicktags" => false
-        ));
+        );
+        $this->setWpEditorSettings($defaultSettings);
+    }
+
+    /**
+     * Allows to replace current WP editor settings with new values
+     * 
+     * @param array $settings
+     */
+    public function setWpEditorSettings($settings) {
+        $this->settings = array_replace($this->settings, $settings);
+    }
+
+    // --- veřejné metody ---------------------------
+
+    public function renderField() {
+        wp_editor($this->getValue(), $this->getName(), $this->settings);
     }
 
 }


### PR DESCRIPTION
Function setWpEditorSettings($settings) allows to replace current WP editor settings with new values.
